### PR TITLE
Use `unscoped` to get all the records

### DIFF
--- a/fixture_builder.gemspec
+++ b/fixture_builder.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{fixture_builder}
-  s.version = "0.2.0"
+  s.version = "0.2.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Ryan Dy", "David Stevenson"]

--- a/lib/fixture_builder.rb
+++ b/lib/fixture_builder.rb
@@ -147,7 +147,7 @@ module FixtureBuilder
         @table_name = table_name
         table_klass = @table_name.classify.constantize rescue nil
         if table_klass
-          rows = table_klass.all.collect(&:attributes)
+          rows = table_klass.unscoped.all.collect(&:attributes)
         else
           rows = ActiveRecord::Base.connection.select_all(select_sql % ActiveRecord::Base.connection.quote_table_name(@table_name))
         end


### PR DESCRIPTION
We have a few models with a default_scope defined, but we still want all records to be used to generate our fixtures. Using `Klass.unscoped.all` will do the trick.
