### PR TITLE
makes `rake spec:fixture_builder:build` work

### DIFF
--- a/fixture_builder.gemspec
+++ b/fixture_builder.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
      "Rakefile",
      "VERSION",
      "fixture_builder.gemspec",
-     "init.rb",
      "lib/fixture_builder.rb",
      "lib/tasks/fixture_builder.rake",
      "test/fixture_builder_test.rb",

--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,0 @@
-# Include hook code here

--- a/lib/fixture_builder.rb
+++ b/lib/fixture_builder.rb
@@ -205,4 +205,10 @@ module FixtureBuilder
       @file_hashes != read_config
     end
   end
+
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      load "tasks/fixture_builder.rake"
+    end
+  end
 end

--- a/lib/tasks/fixture_builder.rake
+++ b/lib/tasks/fixture_builder.rake
@@ -7,18 +7,13 @@ namespace :spec do
       puts "Automatically generated fixtures removed"
     end
 
-    # These tasks don't work properly in rspec2 yet, removing for now
-    # desc "Build the generated fixtures to spec/fixtures if dirty"
-    # task :build do
-    #   puts "Building automatically generated fixtures..."
-    #   raise "Could not rebuild fixtures by running empty specs, look in /tmp/nothing.spec.out" unless system("rake spec:nothing > /tmp/nothing.spec.out")
-    # end
-    # 
-    # desc "Clean and rebuild the generated fixtures to spec/fixtures"
-    # task :rebuild => [:clean, :build]
-  end
+    desc "Build the generated fixtures to spec/fixtures if dirty"
+    task :build => :environment do
+      ActiveRecord::Base.establish_connection('test')
+      Dir.glob(File.join(Rails.root, '{spec,test}', '**', 'fixture_builder.rb')).each{|file| require(file)}
+    end
 
-  # Spec::Rake::SpecTask.new(:nothing) do |t|
-  #   t.spec_files = FileList["spec/spec_helper.rb"]
-  # end
+    desc "Clean and rebuild the generated fixtures to spec/fixtures"
+    task :rebuild => [:clean, :build]
+  end
 end


### PR DESCRIPTION
It's nice to be able to invoke FixtureBuilder with a rake task. Here it is.
