### PR TITLE
Fixes for Rails 2 / Foreign Keys / Empty fixture directories

### DIFF
--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -54,7 +54,9 @@ module FixtureBuilder
     end
 
     def delete_tables
-      tables.each { |t| ActiveRecord::Base.connection.delete(delete_sql % ActiveRecord::Base.connection.quote_table_name(t)) }
+      ActiveRecord::Base.connection.disable_referential_integrity do
+        tables.each { |t| ActiveRecord::Base.connection.delete(delete_sql % ActiveRecord::Base.connection.quote_table_name(t)) }
+      end
     end
 
     def delete_yml_files


### PR DESCRIPTION
These changes allow Rails 2 users, users with foreign key constraints and users with empty fixture directories to use FixtureBuilder.
