### PR TITLE
Use `unscoped` to get all the things

### DIFF
--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -89,7 +89,7 @@ module FixtureBuilder
         fixtures = tables.inject([]) do |files, table_name|
           table_klass = table_name.classify.constantize rescue nil
           if table_klass
-            rows = table_klass.all.collect(&:attributes)
+            rows = table_klass.unscoped {  table_klass.all.collect(&:attributes) }
           else
             rows = ActiveRecord::Base.connection.select_all(select_sql % ActiveRecord::Base.connection.quote_table_name(table_name))
           end

--- a/test/legacy_fixture_mode_fixture_generation_test.rb
+++ b/test/legacy_fixture_mode_fixture_generation_test.rb
@@ -10,6 +10,7 @@ class LegacyFixtureModeFixtureGenerationTest < Test::Unit::TestCase
       fbuilder.legacy_fixtures = Dir[test_path("legacy_fixtures/*.yml"), test_path("other_legacy_fixture_set/*.yml")] 
       fbuilder.factory do
         MagicalCreature.create(:name => "frank", :species => "unicorn")
+        MagicalCreature.create(:name => "loch ness monster", :species => "sea creature", :deleted => true)
       end
     end
 
@@ -38,6 +39,7 @@ class LegacyFixtureModeFixtureGenerationTest < Test::Unit::TestCase
   def test_new_fixtures_are_created
     assert_equal "frank", @@magical_creatures['frank']['name']
     assert_equal "unicorn", @@magical_creatures['frank']['species']
+    assert_equal "loch ness monster", @@magical_creatures['loch_ness_monster']['name']
   end
 
   def test_legacy_fixtures_retain_fixture_name

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,7 @@ require 'fixture_builder'
 
 class MagicalCreature < ActiveRecord::Base
   validates_presence_of :name, :species
+  default_scope :conditions => { :deleted => false }
 end
 
 def create_and_blow_away_old_db
@@ -38,6 +39,7 @@ def create_and_blow_away_old_db
   ActiveRecord::Base.connection.create_table(:magical_creatures, :force => true) do |t|
     t.column :name, :string
     t.column :species, :string
+    t.column :deleted, :boolean, :default => false, :null => false
   end
 end
 


### PR DESCRIPTION
Wow, deja-vu. I strangely feel like I have fixed this bug before. Oh right, I have:
https://github.com/rdy/fixture_builder/pull/3

Somehow this feature got lost with the FixtureBuilder refactor. Here it is again (with tests).

~ Nate & Whitney
