### PR TITLE
Handle edge case where table name matches a global module name

### DIFF
--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -88,7 +88,7 @@ module FixtureBuilder
       begin
         fixtures = tables.inject([]) do |files, table_name|
           table_klass = table_name.classify.constantize rescue nil
-          if table_klass
+          if table_klass && table_klass < ActiveRecord::Base
             rows = table_klass.unscoped {  table_klass.all.collect(&:attributes) }
           else
             rows = ActiveRecord::Base.connection.select_all(select_sql % ActiveRecord::Base.connection.quote_table_name(table_name))


### PR DESCRIPTION
Hey Ryan, this is Jay Phillips -- here's a fix for you that handles an edge case we saw with a table naming having the same name as a global module constant. We have a few other fixes we might want to send your way soon too. :)
