### PR TITLE
Add MIT license to gemspec

### DIFF
--- a/fixture_builder.gemspec
+++ b/fixture_builder.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.authors = ['Ryan Dy', 'David Stevenson']
   s.description = %q{FixtureBuilder allows testers to use their existing factories, like FactoryGirl, to generate high performance fixtures that can be shared across all your tests}
   s.email = %q{mail@ryandy.com}
+  s.licenses = ['MIT']
   s.extra_rdoc_files = [
     'README.markdown'
   ]


### PR DESCRIPTION
Now Rubygems supports a licenses field in the gemspec.
