### PR TITLE
pass in fixtures folder

### DIFF
--- a/lib/fixture_builder/configuration.rb
+++ b/lib/fixture_builder/configuration.rb
@@ -8,7 +8,7 @@ module FixtureBuilder
     include Delegations::Namer
 
     ACCESSIBLE_ATTRIBUTES = [:select_sql, :delete_sql, :skip_tables, :files_to_check, :record_name_fields,
-                             :fixture_builder_file, :after_build, :legacy_fixtures, :model_name_procs]
+                             :fixture_builder_file, :fixture_directory, :after_build, :legacy_fixtures, :model_name_procs]
     attr_accessor(*ACCESSIBLE_ATTRIBUTES)
 
     SCHEMA_FILES = ['db/schema.rb', 'db/development_structure.sql', 'db/test_structure.sql', 'db/production_structure.sql']
@@ -78,8 +78,12 @@ module FixtureBuilder
       ActiveRecord::Base.connection.tables - skip_tables
     end
 
+    def fixture_directory
+      @fixture_directory ||= File.expand_path(File.join(::Rails.root, spec_or_test_dir, 'fixtures'))
+    end
+
     def fixtures_dir(path = '')
-      File.expand_path(File.join(::Rails.root, spec_or_test_dir, 'fixtures', path))
+      File.expand_path(File.join(fixture_directory, path))
     end
 
     private


### PR DESCRIPTION
in a parallel environment, I needed to be able to be able to explicitly set the folder that fixtures should build into.