### PR TITLE
More flexible string interpolation in select_sql and delete_sql

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -77,8 +77,8 @@ By default these are set as:
  * fixture_builder_file: RAILS_ROOT/tmp/fixture_builder.yml
  * record_name_fields: %w{ schema_migrations }
  * skip_tables: %w{ schema_migrations }
- * select_sql: SELECT * FROM %s
- * delete_sql: DELETE FROM %s
+ * select_sql: SELECT * FROM %{table}
+ * delete_sql: DELETE FROM %{table}
 
 Sequence Collisions
 ===================

--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -73,7 +73,7 @@ module FixtureBuilder
 
     def delete_tables
       ActiveRecord::Base.connection.disable_referential_integrity do
-        tables.each { |t| ActiveRecord::Base.connection.delete(delete_sql % ActiveRecord::Base.connection.quote_table_name(t)) }
+        tables.each { |t| ActiveRecord::Base.connection.delete(delete_sql % {table: ActiveRecord::Base.connection.quote_table_name(t)}) }
       end
     end
 
@@ -108,7 +108,7 @@ module FixtureBuilder
               end
             end
           else
-            rows = ActiveRecord::Base.connection.select_all(select_sql % ActiveRecord::Base.connection.quote_table_name(table_name))
+            rows = ActiveRecord::Base.connection.select_all(select_sql % {table: ActiveRecord::Base.connection.quote_table_name(table_name)})
           end
           next files if rows.empty?
 

--- a/lib/fixture_builder/configuration.rb
+++ b/lib/fixture_builder/configuration.rb
@@ -34,11 +34,27 @@ module FixtureBuilder
     end
 
     def select_sql
-      @select_sql ||= "SELECT * FROM %s"
+      @select_sql ||= "SELECT * FROM %{table}"
+    end
+
+    def select_sql=(sql)
+      if sql =~ /%s/
+        ActiveSupport::Deprecation.warn("Passing '%s' into select_sql is deprecated. Please use '%{table}' instead.", caller)
+        sql = sql.sub(/%s/, '%{table}')
+      end
+      @select_sql = sql
     end
 
     def delete_sql
-      @delete_sql ||= "DELETE FROM %s"
+      @delete_sql ||= "DELETE FROM %{table}"
+    end
+
+    def delete_sql=(sql)
+      if sql =~ /%s/
+        ActiveSupport::Deprecation.warn("Passing '%s' into delete_sql is deprecated. Please use '%{table}' instead.", caller)
+        sql = sql.sub(/%s/, '%{table}')
+      end
+      @delete_sql = sql
     end
 
     def skip_tables


### PR DESCRIPTION
Using the hash-based string formating allows using the table name more
than once. e.g. it allows doing this:
```ruby
fbuilder.select_sql = "SELECT * FROM %{table} ORDER BY %{table}.*"
```