### PR TITLE
Only write attributes that have a corresponding column in the database

### DIFF
--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -100,7 +100,7 @@ module FixtureBuilder
           if table_klass && table_klass < ActiveRecord::Base
             rows = table_klass.unscoped do
               table_klass.all.collect do |obj|
-                attrs = obj.attributes
+                attrs = obj.attributes.select{|attr_name| table_klass.column_names.include?(attr_name)}
                 attrs.inject({}) do |hash, (attr_name, value)|
                   hash[attr_name] = serialized_value_if_needed(table_klass, attr_name, value)
                   hash

--- a/lib/fixture_builder/version.rb
+++ b/lib/fixture_builder/version.rb
@@ -1,3 +1,3 @@
 module FixtureBuilder
-  VERSION = '0.5.0-RC1'
+  VERSION = '0.5.0.rc1'
 end


### PR DESCRIPTION
There is a compatibility issue that affects translated columns when using the globalize gem.
For models with translated fields, if the base table does not contain columns for translated fields (which is the recommended usage), and the translated field is set in the factory, the field is being written to the fixtures file for the base model in addition to the translation table. This causes errors when loading the fixtures.

This change ensures that only persisted attributes are written to the fixture files.
