### PR TITLE
fix rails 5 compatability issue

### DIFF
--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -132,7 +132,7 @@ module FixtureBuilder
         if table_klass.type_for_attribute(attr_name).respond_to?(:serialize)
           table_klass.type_for_attribute(attr_name).serialize(value)
         else
-          table_klass.type_for_attribute(attr_name).type_cast_for_database(value)
+          table_klass.type_for_attribute(attr_name).type_cast_for_schema(value)
         end
       else
         if table_klass.serialized_attributes.has_key? attr_name

--- a/lib/fixture_builder/version.rb
+++ b/lib/fixture_builder/version.rb
@@ -1,3 +1,3 @@
 module FixtureBuilder
-  VERSION = '0.5.0-RC1'
+  VERSION = '0.5.0-RC2'
 end


### PR DESCRIPTION
ActiveRecord 5 appears to have deprecated `type_cast_for_database`... Alternative is to use `type_cast_for_schema`
