### PR TITLE
PR41 "Only write attributes that have a corresponding column in the database" with test

### DIFF
--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -100,7 +100,7 @@ module FixtureBuilder
           if table_klass && table_klass < ActiveRecord::Base
             rows = table_klass.unscoped do
               table_klass.all.collect do |obj|
-                attrs = obj.attributes
+                attrs = obj.attributes.select { |attr_name| table_klass.column_names.include?(attr_name) }
                 attrs.inject({}) do |hash, (attr_name, value)|
                   hash[attr_name] = serialized_value_if_needed(table_klass, attr_name, value)
                   hash

--- a/test/fixture_builder_test.rb
+++ b/test/fixture_builder_test.rb
@@ -65,7 +65,6 @@ class FixtureBuilderTest < Test::Unit::TestCase
       end
     end
     generated_fixture = YAML.load(File.open(test_path('fixtures/magical_creatures.yml')))
-    puts generated_fixture
     assert !generated_fixture['uni'].key?('virtual')
   end
 

--- a/test/fixture_builder_test.rb
+++ b/test/fixture_builder_test.rb
@@ -54,6 +54,21 @@ class FixtureBuilderTest < Test::Unit::TestCase
     assert_equal "---\n- shading\n- rooting\n- seeding\n", generated_fixture['enty']['powers']
   end
 
+  def test_do_not_include_virtual_attributes
+    create_and_blow_away_old_db
+    force_fixture_generation
+
+    FixtureBuilder.configure do |fbuilder|
+      fbuilder.files_to_check += Dir[test_path("*.rb")]
+      fbuilder.factory do
+        MagicalCreature.create(:name => 'Uni', :species => 'unicorn', :powers => %w{rainbows flying})
+      end
+    end
+    generated_fixture = YAML.load(File.open(test_path('fixtures/magical_creatures.yml')))
+    puts generated_fixture
+    assert !generated_fixture['uni'].key?('virtual')
+  end
+
   def test_configure
     FixtureBuilder.configure do |config|
       assert config.is_a?(FixtureBuilder::Configuration)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,6 +33,8 @@ class MagicalCreature < ActiveRecord::Base
 
   if ActiveRecord::VERSION::MAJOR >= 4
     default_scope -> { where(:deleted => false) }
+
+    attribute :virtual, ActiveRecord::Type::Integer.new
   else
     default_scope :conditions => { :deleted => false }
   end


### PR DESCRIPTION
Based on https://github.com/rdy/fixture_builder/pull/41/files , but with a test!

Ideally virtual attributes would not be included in fixture output as they then break loading as they have no corresponding column