### PR TITLE
Stabilize order of records in YAML files

### DIFF
--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -99,7 +99,7 @@ module FixtureBuilder
           table_klass = table_name.classify.constantize rescue nil
           if table_klass && table_klass < ActiveRecord::Base
             rows = table_klass.unscoped do
-              table_klass.all.collect do |obj|
+              table_klass.order(:id).all.collect do |obj|
                 attrs = obj.attributes.select { |attr_name| table_klass.column_names.include?(attr_name) }
                 attrs.inject({}) do |hash, (attr_name, value)|
                   hash[attr_name] = serialized_value_if_needed(table_klass, attr_name, value)


### PR DESCRIPTION
Without this PR, some databases cause generated fixtures to appear in arbitrary order, which creates large diffs upon minor modifications to the fixture structure.