### PR TITLE
Support version 1.0.0 of Hashdiff

### DIFF
--- a/lib/fixture_builder/configuration.rb
+++ b/lib/fixture_builder/configuration.rb
@@ -5,6 +5,13 @@ require 'fileutils'
 require 'hashdiff'
 
 module FixtureBuilder
+  if Object.const_defined?(:Hashdiff)
+    # hashdiff version >= 1.0.0
+    Differ = Hashdiff
+  else
+    Differ = HashDiff
+  end
+
   class Configuration
     include Delegations::Namer
 
@@ -135,7 +142,7 @@ module FixtureBuilder
         return true
       elsif file_hashes_from_disk != file_hashes_from_config
         puts '=> rebuilding fixtures because one or more of the following files have changed (see http://www.rubydoc.info/gems/hashdiff for diff syntax):'
-        HashDiff.diff(file_hashes_from_disk, file_hashes_from_config).map {|diff| print '   '; p diff}
+        Differ.diff(file_hashes_from_disk, file_hashes_from_config).map {|diff| print '   '; p diff}
         return true
       end
       false

--- a/test/fixture_builder_test.rb
+++ b/test/fixture_builder_test.rb
@@ -1,6 +1,5 @@
 require File.expand_path(File.join(File.dirname(__FILE__), 'test_helper'))
 
-
 class Model
   def self.table_name
     'models'
@@ -82,5 +81,20 @@ class FixtureBuilderTest < Test::Unit::TestCase
 
   def test_fixtures_dir
     assert_match /test\/fixtures$/, FixtureBuilder.configuration.send(:fixtures_dir).to_s
+  end
+
+  def test_rebuilding_due_to_differing_file_hashes
+    create_and_blow_away_old_db
+    force_fixture_generation_due_to_differing_file_hashes
+
+    FixtureBuilder.configure do |fbuilder|
+      fbuilder.files_to_check += Dir[test_path("*.rb")]
+      fbuilder.factory do
+        @enty = MagicalCreature.create(:name => 'Enty', :species => 'ent',
+                                       :powers => %w{shading rooting seeding})
+      end
+    end
+    generated_fixture = YAML.load(File.open(test_path("fixtures/magical_creatures.yml")))
+    assert_equal "---\n- shading\n- rooting\n- seeding\n", generated_fixture['enty']['powers']
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,3 +61,11 @@ def force_fixture_generation
   rescue
   end
 end
+
+def force_fixture_generation_due_to_differing_file_hashes
+  begin
+    path = File.expand_path("../../tmp/fixture_builder.yml", __FILE__)
+    File.write(path, "blah blah blah")
+  rescue
+  end
+end


### PR DESCRIPTION
In version 1.0.0, the `hashdiff` gem changed its module name from `HashDiff` to `Hashdiff` to prevent name collision with the `hash_diff` gem (more information: https://github.com/liufengyun/hashdiff/issues/45).

The API did not change.

This commit updates fixture_builder to support the new version of hashdiff.

If you'd like, I could add some code that will seamlessly use `Hashdiff` or `HashDiff` depending on which one is available, and make this not a breaking change. Up to you!