### PR TITLE
Add `ar_internal_metadata` table to default value of `skip_tables`

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -147,7 +147,7 @@ By default these are set as:
 * files_to_check: %w{ db/schema.rb }
 * fixture_builder_file: RAILS_ROOT/tmp/fixture_builder.yml
 * record_name_fields: %w{ unique_name display_name name title username login }
-* skip_tables: %w{ schema_migrations }
+* skip_tables: %w{ schema_migrations ar_internal_metadata }
 * select_sql: SELECT * FROM %{table}
 * delete_sql: DELETE FROM %{table}
 

--- a/lib/fixture_builder/configuration.rb
+++ b/lib/fixture_builder/configuration.rb
@@ -75,7 +75,7 @@ module FixtureBuilder
     end
 
     def skip_tables
-      @skip_tables ||= %w[schema_migrations]
+      @skip_tables ||= %w[schema_migrations ar_internal_metadata]
     end
 
     def files_to_check


### PR DESCRIPTION
`ar_internal_metadata` table was added at Rails 5.0 (ref. rails/rails#22967) for prevent destructive action on production database.
It is also created on other rails environment other than production(e.g. development/test).
So, I added it to default value of `skip_tables`.