### PR TITLE
Add table-specific configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ pkg/
 .idea/*
 *.db
 tmp/fixture_builder.yml
-test/fixtures/magical_creatures.yml
+test/fixtures/**/*.yml
 Gemfile.lock
 *.gem

--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -96,7 +96,7 @@ module FixtureBuilder
       Date::DATE_FORMATS[:default] = Date::DATE_FORMATS[:db]
       begin
         fixtures = tables.inject([]) do |files, table_name|
-          table_klass = table_name.classify.constantize rescue nil
+          table_klass = fixture_classes[table_name] || table_name.classify.constantize rescue nil
           if table_klass && table_klass < ActiveRecord::Base
             rows = table_klass.unscoped do
               table_klass.order(:id).all.collect do |obj|
@@ -154,7 +154,8 @@ module FixtureBuilder
     end
 
     def fixture_file(table_name)
-      fixtures_dir("#{table_name}.yml")
+      file_name = fixture_files[table_name] || table_name
+      fixtures_dir("#{file_name}.yml")
     end
   end
 end

--- a/lib/fixture_builder/configuration.rb
+++ b/lib/fixture_builder/configuration.rb
@@ -110,7 +110,12 @@ module FixtureBuilder
     end
 
     def fixtures_dir(path = '')
-      File.expand_path(File.join(fixture_directory, path))
+      subdirs = path.split('/')
+      path = subdirs.pop || ''
+      dir = File.expand_path(File.join(fixture_directory, *subdirs))
+
+      FileUtils.mkdir_p(dir)
+      File.join(dir, path)
     end
 
     private

--- a/lib/fixture_builder/configuration.rb
+++ b/lib/fixture_builder/configuration.rb
@@ -118,6 +118,39 @@ module FixtureBuilder
       File.join(dir, path)
     end
 
+    # This allows for configuring fixtures for a given database table; you may
+    # set the model class for the table (e.g. for legacy tables) and the name
+    # of the resulting fixture file for the table (e.g. for nested fixtures).
+    #
+    # For example:
+    #
+    #   FixtureBuilder.configure do |fbuilder|
+    #     fbuilder.configure_tables(wibbles: {
+    #       class: Legacy::Things,
+    #       file: 'legacy/things'
+    #     })
+    #   end
+    #
+    # This will tell the builder to use the `Legacy::Things` class to serialize
+    # fixtured dumped from the `wibbles` table, and to dump the `wibbles` table
+    # into the `legacy_things.yml` file.  This also works with nested
+    # directories, which will map to namespaced fixtures.
+    def configure_tables(configuration)
+      configuration.each do |table_name, table_config|
+        table_name = table_name.to_s
+        fixture_classes.merge!(table_name => table_config[:class])
+        fixture_files.merge!(table_name => table_config[:file])
+      end
+    end
+
+    def fixture_classes
+      @fixture_classes ||= {}
+    end
+
+    def fixture_files
+      @fixture_files ||= {}
+    end
+
     private
 
     def file_hashes

--- a/lib/fixture_builder/delegations.rb
+++ b/lib/fixture_builder/delegations.rb
@@ -4,7 +4,7 @@ module FixtureBuilder
   module Delegations
     module Configuration
       def self.included(base)
-        methods_to_delegate = [:fixtures_dir, :tables, :legacy_fixtures].concat(::FixtureBuilder::Configuration::ACCESSIBLE_ATTRIBUTES).flatten
+        methods_to_delegate = [:fixtures_dir, :tables, :legacy_fixtures, :fixture_classes, :fixture_files].concat(::FixtureBuilder::Configuration::ACCESSIBLE_ATTRIBUTES).flatten
         methods_to_delegate.each do |meth|
           base.delegate(meth, :to => :@configuration)
         end

--- a/test/fixture_builder_test.rb
+++ b/test/fixture_builder_test.rb
@@ -80,7 +80,13 @@ class FixtureBuilderTest < Test::Unit::TestCase
   end
 
   def test_fixtures_dir
-    assert_match /test\/fixtures$/, FixtureBuilder.configuration.send(:fixtures_dir).to_s
+    file_path = "wibble.yml"
+    assert_match(/test\/fixtures\/#{file_path}$/, FixtureBuilder.configuration.send(:fixtures_dir, file_path).to_s)
+  end
+
+  def test_nested_fixtures_dir
+    file_path = "foo/bar/wibble.yml"
+    assert_match(/test\/fixtures\/#{file_path}$/, FixtureBuilder.configuration.send(:fixtures_dir, file_path).to_s)
   end
 
   def test_rebuilding_due_to_differing_file_hashes

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,10 +41,19 @@ class MagicalCreature < ActiveRecord::Base
 end
 
 def create_and_blow_away_old_db
-  ActiveRecord::Base.configurations['test'] = {
-      'adapter' => 'sqlite3',
-      'database' => 'test.db'
-  }
+  if ActiveRecord::VERSION::MAJOR >= 7
+    ActiveRecord::Base.configurations = {
+      test: {
+        'adapter' => 'sqlite3',
+        'database' => 'test.db'
+      }
+    }
+  else
+    ActiveRecord::Base.configurations['test'] = {
+        'adapter' => 'sqlite3',
+        'database' => 'test.db'
+    }
+  end
   ActiveRecord::Base.establish_connection(:test)
 
   ActiveRecord::Base.connection.create_table(:magical_creatures, :force => true) do |t|


### PR DESCRIPTION
Hey Chad, I've been working with some legacy projects which present unusual requirements for fixture_builder (e.g. in some cases I need more than one table for the same domain concept, and the naming is somewhat all over the place).  I made some minor configuration enhancements here that allow the user to specify the model class and output file for a particular table.

So, for example, if you have the `wibbles` table, but you want the associated model class to be `Legacy::Foo` and the fixture file to be 'legacy/foos' this will allow you to do that with the following:

```ruby
FixtureBuilder.configure do |fbuilder|
  ...
  fbuilder.configure_tables(wibbles: { file: "legacy/foos", class: Legacy::Foo })
  ...
end
```

Incidentally, I use FixtureBuilder pretty regularly and I'm happy to help with maintenance, if you need.  I'd like to ensure that it survives, because it's damn useful.